### PR TITLE
Remove environment from check

### DIFF
--- a/checker.proto
+++ b/checker.proto
@@ -36,7 +36,6 @@ message Check {
 	Target target = 3;
 	Timestamp last_run = 4;
 	Any check_spec = 5;
-	string environment_id = 6;
 }
 
 message Header {


### PR DESCRIPTION
In the db, checks now have an associated customer id, but can't see a reason to put it in the proto. Let me know if there is.
