### PR TITLE
add initial version of aws proto

### DIFF
--- a/aws.proto
+++ b/aws.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.FieldOptions {
+    bool is_required = 60000;
+}
+
+extend google.protobuf.EnumValueOptions {
+    string enum_name = 51234;
+}
+
+package aws_proto;
+
+option java_package = "co.opsee.proto";
+option java_multiple_files = true;
+option java_outer_classname = "BastionProto";
+
+service ec2 {
+    rpc StartInstances(StartInstancesRequest) returns(StartInstancesResult) {}
+    rpc StopInstances(StopInstancesRequest) returns(StopInstancesResult) {}
+}
+
+message StopInstancesRequest {
+   bool dryRun = 1;
+   bool force = 2;
+   repeated string InstanceIds = 3 [(is_required)=true];
+}
+
+message StopInstancesResult {
+   repeated InstanceStateChange StoppingInstances = 1;
+}
+
+message StartInstancesRequest {
+   string additionalInfo = 1;
+   bool dryRun = 2;
+   repeated string InstanceIds = 3 [(is_required)=true];
+}
+
+message InstanceState {
+   string code = 1;
+   string name = 2;
+}
+message InstanceStateChange {
+   string instanceId = 1;
+   InstanceState currentState = 2;
+   string previousState = 3;
+}
+
+message StartInstancesResult {
+   repeated InstanceStateChange StartingInstances = 1;
+}
+
+


### PR DESCRIPTION
Adds grpc calls for ec2.StartInstances and ec2.StopInstances along with the messages which describe required structures
